### PR TITLE
chore: add README to crates, fix docs URL, add crates.io badge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ keywords = ["sloc", "code-analysis", "cli", "static-analysis", "metrics"]
 categories = ["command-line-utilities", "development-tools"]
 repository = "https://github.com/oxide-sloc/oxide-sloc"
 homepage = "https://github.com/oxide-sloc/oxide-sloc"
-documentation = "https://github.com/oxide-sloc/oxide-sloc"
+documentation = "https://docs.rs/oxide-sloc"
+readme = "README.md"
 rust-version = "1.95"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -4,11 +4,22 @@
 [![Release](https://github.com/oxide-sloc/oxide-sloc/actions/workflows/release.yml/badge.svg)](https://github.com/oxide-sloc/oxide-sloc/actions/workflows/release.yml)
 [![Docker](https://github.com/oxide-sloc/oxide-sloc/actions/workflows/docker.yml/badge.svg)](https://github.com/oxide-sloc/oxide-sloc/actions/workflows/docker.yml)
 [![Latest Release](https://img.shields.io/github/v/release/oxide-sloc/oxide-sloc?include_prereleases&label=release)](https://github.com/oxide-sloc/oxide-sloc/releases/latest)
+[![crates.io](https://img.shields.io/crates/v/oxide-sloc.svg)](https://crates.io/crates/oxide-sloc)
 [![License: AGPL-3.0-or-later](https://img.shields.io/badge/license-AGPL--3.0--or--later-blue.svg)](./LICENSE)
 
 **oxide-sloc** is a Rust-based source line analysis tool — IEEE 1045-1992 compliant, more than a line counter.
 
 ## Quick Start
+
+**Install via Cargo (requires Rust):**
+
+```bash
+cargo install oxide-sloc
+oxide-sloc serve          # web UI at http://127.0.0.1:4317
+oxide-sloc analyze ./my-repo --plain
+```
+
+**Or use a pre-built binary:**
 
 | Platform | Install | Launch |
 |---|---|---|

--- a/crates/sloc-config/Cargo.toml
+++ b/crates/sloc-config/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 documentation.workspace = true
 rust-version.workspace = true
 description.workspace = true
+readme = "../../README.md"
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/sloc-core/Cargo.toml
+++ b/crates/sloc-core/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 documentation.workspace = true
 rust-version.workspace = true
 description.workspace = true
+readme = "../../README.md"
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/sloc-languages/Cargo.toml
+++ b/crates/sloc-languages/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 documentation.workspace = true
 rust-version.workspace = true
 description.workspace = true
+readme = "../../README.md"
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/sloc-report/Cargo.toml
+++ b/crates/sloc-report/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 documentation.workspace = true
 rust-version.workspace = true
 description.workspace = true
+readme = "../../README.md"
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/sloc-web/Cargo.toml
+++ b/crates/sloc-web/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 documentation.workspace = true
 rust-version.workspace = true
 description.workspace = true
+readme = "../../README.md"
 keywords.workspace = true
 categories.workspace = true
 


### PR DESCRIPTION
## Summary

- Add `readme = "../../README.md"` to all library crates so crates.io shows the project README on each crate page (currently shows nothing)
- Update `documentation` URL from GitHub to `https://docs.rs/oxide-sloc`
- Add `[![crates.io](https://img.shields.io/crates/v/oxide-sloc.svg)](https://crates.io/crates/oxide-sloc)` badge to README
- Add `cargo install oxide-sloc` as the primary Quick Start method in README

## Test plan

- [ ] CI passes (fmt, clippy, build, tests)
- [ ] After merge, republish crates to pick up readme changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)