### PR TITLE
fix(clippy): resolve 19 pedantic/nursery findings (A2/A3/A4)

### DIFF
--- a/crates/sloc-core/src/lib.rs
+++ b/crates/sloc-core/src/lib.rs
@@ -28,6 +28,16 @@ use sloc_languages::{
     RawLineCounts,
 };
 
+/// Three-way outcome for metadata-level policy checks.
+enum MetadataPolicyOutcome {
+    /// Skip this file — include the record in output.
+    Skip(Box<FileRecord>),
+    /// Exclude this file entirely — no record in output (include-glob miss).
+    Exclude,
+    /// Continue to content checks.
+    Continue,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FileStatus {
@@ -446,10 +456,8 @@ fn push_record(
 }
 
 /// Apply metadata-level policy checks (symlink, name, dir exclusion, size, globs, lockfile).
-/// Returns `Ok(Some(record))` to skip, `Ok(None)` to continue, or an early `Ok(None)` to
-/// exclude from output entirely (include-glob miss).
-///
-/// Returns `Err` only on internal I/O errors that should propagate.
+/// Returns `Skip(record)` to skip, `Exclude` to omit from output entirely (include-glob miss),
+/// or `Continue` to proceed to content checks.
 #[allow(clippy::too_many_arguments)]
 fn check_metadata_policy(
     path: &Path,
@@ -459,43 +467,39 @@ fn check_metadata_policy(
     config: &AppConfig,
     include_globs: Option<&GlobSet>,
     exclude_globs: Option<&GlobSet>,
-) -> Result<Option<Option<FileRecord>>> {
-    // Returns Ok(Some(Some(record))) → skip with this record
-    //         Ok(Some(None))         → exclude silently (include-glob miss)
-    //         Ok(None)               → continue to content checks
-
+) -> MetadataPolicyOutcome {
     if metadata.file_type().is_symlink() && !config.discovery.follow_symlinks {
-        return Ok(Some(Some(skipped_record(
+        return MetadataPolicyOutcome::Skip(Box::new(skipped_record(
             path,
             root,
             metadata.len(),
             FileStatus::SkippedByPolicy,
             vec!["symlink skipped by policy".into()],
-        ))));
+        )));
     }
 
     if file_name_eq(path, ".gitignore") {
-        return Ok(Some(Some(skipped_record(
+        return MetadataPolicyOutcome::Skip(Box::new(skipped_record(
             path,
             root,
             metadata.len(),
             FileStatus::SkippedByPolicy,
             vec![".gitignore is always excluded".into()],
-        ))));
+        )));
     }
 
     if is_excluded_dir_path(path, &config.discovery.excluded_directories) {
-        return Ok(Some(Some(skipped_record(
+        return MetadataPolicyOutcome::Skip(Box::new(skipped_record(
             path,
             root,
             metadata.len(),
             FileStatus::SkippedByPolicy,
             vec!["path matched excluded directory setting".into()],
-        ))));
+        )));
     }
 
     if metadata.len() > config.discovery.max_file_size_bytes {
-        return Ok(Some(Some(skipped_record(
+        return MetadataPolicyOutcome::Skip(Box::new(skipped_record(
             path,
             root,
             metadata.len(),
@@ -504,52 +508,53 @@ fn check_metadata_policy(
                 "file exceeded max_file_size_bytes ({})",
                 config.discovery.max_file_size_bytes
             )],
-        ))));
+        )));
     }
 
     if let Some(globs) = include_globs {
         if !globs.is_match(Path::new(relative_path)) && !globs.is_match(path) {
-            return Ok(Some(None));
+            return MetadataPolicyOutcome::Exclude;
         }
     }
 
     if let Some(globs) = exclude_globs {
         if globs.is_match(Path::new(relative_path)) || globs.is_match(path) {
-            return Ok(Some(Some(skipped_record(
+            return MetadataPolicyOutcome::Skip(Box::new(skipped_record(
                 path,
                 root,
                 metadata.len(),
                 FileStatus::SkippedByPolicy,
                 vec!["path matched exclude glob".into()],
-            ))));
+            )));
         }
     }
 
     if is_known_lockfile(path) && !config.analysis.include_lockfiles {
-        return Ok(Some(Some(skipped_record(
+        return MetadataPolicyOutcome::Skip(Box::new(skipped_record(
             path,
             root,
             metadata.len(),
             FileStatus::SkippedByPolicy,
             vec!["lockfile skipped by default policy".into()],
-        ))));
+        )));
     }
 
-    Ok(None)
+    MetadataPolicyOutcome::Continue
 }
 
 /// Apply content-level policy checks (vendor, generated, minified, binary).
-/// Returns `Ok(Some(record))` to skip, `Ok(None)` to continue.
+/// Returns `(vendor, generated, minified, skip_record)` where `skip_record` is `Some` when
+/// the file should be skipped.
 fn check_content_policy(
     path: &Path,
     root: &Path,
     size_bytes: u64,
     bytes: &[u8],
     config: &AppConfig,
-) -> Result<(bool, bool, bool, Option<FileRecord>)> {
+) -> (bool, bool, bool, Option<FileRecord>) {
     let vendor = is_vendor_path(path);
     if vendor && config.analysis.vendor_directory_detection {
-        return Ok((
+        return (
             vendor,
             false,
             false,
@@ -560,12 +565,12 @@ fn check_content_policy(
                 FileStatus::SkippedByPolicy,
                 vec!["vendor file skipped by policy".into()],
             )),
-        ));
+        );
     }
 
     let generated = config.analysis.generated_file_detection && looks_generated(path, bytes);
     if generated {
-        return Ok((
+        return (
             vendor,
             generated,
             false,
@@ -576,12 +581,12 @@ fn check_content_policy(
                 FileStatus::SkippedByPolicy,
                 vec!["generated file skipped by policy".into()],
             )),
-        ));
+        );
     }
 
     let minified = config.analysis.minified_file_detection && looks_minified(path, bytes);
     if minified {
-        return Ok((
+        return (
             vendor,
             generated,
             minified,
@@ -592,10 +597,10 @@ fn check_content_policy(
                 FileStatus::SkippedByPolicy,
                 vec!["minified file skipped by policy".into()],
             )),
-        ));
+        );
     }
 
-    Ok((vendor, generated, minified, None))
+    (vendor, generated, minified, None)
 }
 
 /// Decode file bytes to a UTF-8 string, handling binary detection and decode failures.
@@ -665,10 +670,10 @@ fn analyze_candidate_file(
         config,
         include_globs,
         exclude_globs,
-    )? {
-        Some(Some(record)) => return Ok(Some(record)),
-        Some(None) => return Ok(None),
-        None => {}
+    ) {
+        MetadataPolicyOutcome::Skip(record) => return Ok(Some(*record)),
+        MetadataPolicyOutcome::Exclude => return Ok(None),
+        MetadataPolicyOutcome::Continue => {}
     }
 
     let bytes = match fs::read(path) {
@@ -686,7 +691,7 @@ fn analyze_candidate_file(
 
     // Content-level policy checks (vendor, generated, minified).
     let (vendor, generated, minified, skip_record) =
-        check_content_policy(path, root, metadata.len(), &bytes, config)?;
+        check_content_policy(path, root, metadata.len(), &bytes, config);
     if let Some(record) = skip_record {
         return Ok(Some(record));
     }

--- a/crates/sloc-languages/src/lib.rs
+++ b/crates/sloc-languages/src/lib.rs
@@ -2049,11 +2049,11 @@ fn try_record_docstring_if_context(
 
 /// If an unclosed docstring is still active at end-of-file, mark all remaining lines.
 fn mark_unclosed_docstring_lines(
-    active_docstring: &Option<(&'static str, usize)>,
+    active_docstring: Option<&(&'static str, usize)>,
     docstring_lines: &mut HashSet<usize>,
     num_lines: usize,
 ) {
-    if let Some((_, start_line)) = *active_docstring {
+    if let Some(&(_, start_line)) = active_docstring {
         for idx in start_line..num_lines {
             docstring_lines.insert(idx);
         }
@@ -2103,7 +2103,7 @@ fn detect_python_docstring_lines(text: &str) -> HashSet<usize> {
         }
     }
 
-    mark_unclosed_docstring_lines(&active_docstring, &mut docstring_lines, lines.len());
+    mark_unclosed_docstring_lines(active_docstring.as_ref(), &mut docstring_lines, lines.len());
 
     docstring_lines
 }
@@ -2156,7 +2156,8 @@ fn closes_triple_docstring(trimmed: &str, delim: &str, same_line_as_start: bool)
     }
 }
 
-/// Tree-sitter-backed adapters. Compiled only when the `tree-sitter` feature is enabled.
+/// Tree-sitter-backed adapters (compiled only when the `tree-sitter` feature is enabled).
+///
 /// When parsing succeeds the result is used directly; on any failure the caller falls back
 /// to the lexical state machine.
 #[cfg(feature = "tree-sitter")]
@@ -2171,12 +2172,12 @@ pub mod ts {
     /// `docstring_stmt_kind` — optional parent node type whose direct `string` child is a docstring
     fn analyze_lines(
         text: &str,
-        ts_language: tree_sitter::Language,
+        ts_language: &tree_sitter::Language,
         comment_node_kinds: &[&str],
         docstring_stmt_kind: Option<&str>,
     ) -> Option<RawFileAnalysis> {
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&ts_language).ok()?;
+        parser.set_language(ts_language).ok()?;
         let tree = parser.parse(text, None)?;
 
         let lines: Vec<&str> = text.split_terminator('\n').collect();
@@ -2216,28 +2217,32 @@ pub mod ts {
         })
     }
 
-    /// Classify a single tree-sitter-annotated line and accumulate into `raw`.
-    fn classify_ts_line(
-        trimmed: &str,
+    /// Flags describing what kinds of content appear on a single line.
+    // Four bools are the natural representation for these four independent properties.
+    #[allow(clippy::struct_excessive_bools)]
+    #[derive(Clone, Copy)]
+    struct TsLineFlags {
         has_code: bool,
         has_comment: bool,
         comment_is_block: bool,
         has_docstring: bool,
-        raw: &mut RawLineCounts,
-    ) {
+    }
+
+    /// Classify a single tree-sitter-annotated line and accumulate into `raw`.
+    const fn classify_ts_line(trimmed: &str, flags: TsLineFlags, raw: &mut RawLineCounts) {
         if trimmed.is_empty() {
             raw.blank_only_lines += 1;
-        } else if has_docstring && !has_code {
+        } else if flags.has_docstring && !flags.has_code {
             raw.docstring_comment_lines += 1;
-        } else if has_code && has_comment {
+        } else if flags.has_code && flags.has_comment {
             // Classify the mixed line as single or multi based on what kind of comment is on it.
-            if comment_is_block {
+            if flags.comment_is_block {
                 raw.mixed_code_multi_comment_lines += 1;
             } else {
                 raw.mixed_code_single_comment_lines += 1;
             }
-        } else if has_comment {
-            if comment_is_block {
+        } else if flags.has_comment {
+            if flags.comment_is_block {
                 raw.multi_comment_only_lines += 1;
             } else {
                 raw.single_comment_only_lines += 1;
@@ -2260,10 +2265,12 @@ pub mod ts {
             raw.total_physical_lines += 1;
             classify_ts_line(
                 lines[i].trim(),
-                has_code[i],
-                has_comment[i],
-                comment_is_block[i],
-                has_docstring[i],
+                TsLineFlags {
+                    has_code: has_code[i],
+                    has_comment: has_comment[i],
+                    comment_is_block: comment_is_block[i],
+                    has_docstring: has_docstring[i],
+                },
                 raw,
             );
         }
@@ -2299,19 +2306,17 @@ pub mod ts {
         }
     }
 
-    /// If `node` is an expression_statement whose sole named child is a string literal,
+    /// If `node` is an `expression_statement` whose sole named child is a string literal,
     /// mark those rows as docstring and return `true`.
     fn visit_maybe_docstring(node: Node, kind: &str, ctx: &mut VisitCtx<'_>) -> bool {
-        let stmt_kind = match ctx.docstring_stmt_kind {
-            Some(k) => k,
-            None => return false,
+        let Some(stmt_kind) = ctx.docstring_stmt_kind else {
+            return false;
         };
         if kind != stmt_kind || node.named_child_count() != 1 {
             return false;
         }
-        let child = match node.named_child(0) {
-            Some(c) => c,
-            None => return false,
+        let Some(child) = node.named_child(0) else {
+            return false;
         };
         if child.kind() != "string" {
             return false;
@@ -2367,18 +2372,17 @@ pub mod ts {
     }
 
     /// Parse C or C++ source with tree-sitter-c.
+    #[must_use]
     pub fn analyze_c(text: &str) -> Option<RawFileAnalysis> {
-        analyze_lines(text, tree_sitter_c::LANGUAGE.into(), &["comment"], None)
+        let lang: tree_sitter::Language = tree_sitter_c::LANGUAGE.into();
+        analyze_lines(text, &lang, &["comment"], None)
     }
 
     /// Parse Python source with tree-sitter-python.
+    #[must_use]
     pub fn analyze_python(text: &str) -> Option<RawFileAnalysis> {
-        analyze_lines(
-            text,
-            tree_sitter_python::LANGUAGE.into(),
-            &["comment"],
-            Some("expression_statement"),
-        )
+        let lang: tree_sitter::Language = tree_sitter_python::LANGUAGE.into();
+        analyze_lines(text, &lang, &["comment"], Some("expression_statement"))
     }
 }
 

--- a/crates/sloc-web/src/lib.rs
+++ b/crates/sloc-web/src/lib.rs
@@ -92,30 +92,32 @@ impl IpRateLimiter {
     }
 
     fn record_auth_failure(&self, ip: IpAddr) {
+        let now = Instant::now();
         let mut map = self
             .auth_failures
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let entry = map.entry(ip).or_insert((0, Instant::now()));
-        entry.0 += 1;
-        entry.1 = Instant::now();
+        map.entry(ip)
+            .and_modify(|e| {
+                e.0 += 1;
+                e.1 = now;
+            })
+            .or_insert_with(|| (1, now));
     }
 
     fn is_auth_locked_out(&self, ip: IpAddr) -> bool {
-        let lockout_threshold = 10u32;
-        let lockout_window = Duration::from_secs(3600);
+        const LOCKOUT_THRESHOLD: u32 = 10;
+        const LOCKOUT_WINDOW: Duration = Duration::from_hours(1);
         let mut map = self
             .auth_failures
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let Some(entry) = map.get_mut(&ip) else {
-            return false;
-        };
-        if entry.1.elapsed() > lockout_window {
+        let expired = map.get(&ip).is_some_and(|e| e.1.elapsed() > LOCKOUT_WINDOW);
+        if expired {
             map.remove(&ip);
             return false;
         }
-        entry.0 >= lockout_threshold
+        map.get(&ip).is_some_and(|e| e.0 >= LOCKOUT_THRESHOLD)
     }
 }
 
@@ -152,6 +154,9 @@ struct RunArtifacts {
 /// # Panics
 ///
 /// Panics if the Axum router fails to build (only occurs on misconfigured routes).
+// The function coordinates TLS setup, router construction, and async listener setup in one
+// place; splitting it further would require passing many state values across function boundaries.
+#[allow(clippy::too_many_lines)]
 pub async fn serve(config: AppConfig) -> Result<()> {
     let bind_address = config.web.bind_address.clone();
     let server_mode = config.web.server_mode;
@@ -468,8 +473,7 @@ async fn require_api_key(
         let peer_ip = req
             .extensions()
             .get::<axum::extract::ConnectInfo<SocketAddr>>()
-            .map(|c| c.0.ip())
-            .unwrap_or(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+            .map_or(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED), |c| c.0.ip());
 
         if state.rate_limiter.is_auth_locked_out(peer_ip) {
             tracing::warn!(event = "auth_lockout", peer_addr = %peer_ip,
@@ -1318,7 +1322,7 @@ fn apply_output_dir_exclusions(
 }
 
 /// Build a `ScanSummarySnapshot` from an `AnalysisRun`'s `summary_totals`.
-fn summary_snapshot_from_run(run: &AnalysisRun) -> ScanSummarySnapshot {
+const fn summary_snapshot_from_run(run: &AnalysisRun) -> ScanSummarySnapshot {
     ScanSummarySnapshot {
         files_analyzed: run.summary_totals.files_analyzed,
         files_skipped: run.summary_totals.files_skipped,
@@ -1499,6 +1503,10 @@ fn build_submodule_row(
     }
 }
 
+// This Axum handler manages the full analysis lifecycle including config, execution, artifact
+// writing, and response rendering; splitting it would require threading many borrowed values
+// through async boundaries, complicating Send requirements.
+#[allow(clippy::too_many_lines)]
 #[allow(clippy::similar_names)]
 async fn analyze_handler(
     State(state): State<AppState>,
@@ -1865,8 +1873,8 @@ fn build_pdf_filename(report_title: &str, run_id: &str) -> String {
 }
 
 /// Serve the HTML artifact for a run — view or download.
-fn serve_html_artifact(path: PathBuf, wants_download: bool, csp_nonce: &str) -> Response {
-    match fs::read_to_string(&path) {
+fn serve_html_artifact(path: &Path, wants_download: bool, csp_nonce: &str) -> Response {
+    match fs::read_to_string(path) {
         Ok(content) => {
             if wants_download {
                 (
@@ -1910,13 +1918,13 @@ fn serve_html_artifact(path: PathBuf, wants_download: bool, csp_nonce: &str) -> 
 
 /// Serve the PDF artifact for a run — inline or download.
 fn serve_pdf_artifact(
-    path: PathBuf,
+    path: &Path,
     report_title: &str,
     run_id: &str,
     wants_download: bool,
     csp_nonce: &str,
 ) -> Response {
-    match fs::read(&path) {
+    match fs::read(path) {
         Ok(bytes) => {
             let filename = build_pdf_filename(report_title, run_id);
             let disposition = if wants_download {
@@ -1958,8 +1966,8 @@ fn serve_pdf_artifact(
 }
 
 /// Serve the JSON artifact for a run — view or download.
-fn serve_json_artifact(path: PathBuf, wants_download: bool, csp_nonce: &str) -> Response {
-    match fs::read(&path) {
+fn serve_json_artifact(path: &Path, wants_download: bool, csp_nonce: &str) -> Response {
+    match fs::read(path) {
         Ok(bytes) => {
             if wants_download {
                 (
@@ -2074,7 +2082,7 @@ async fn artifact_handler(
             let Some(path) = artifact_set.html_path else {
                 return StatusCode::NOT_FOUND.into_response();
             };
-            serve_html_artifact(path, wants_download, &csp_nonce)
+            serve_html_artifact(&path, wants_download, &csp_nonce)
         }
         "pdf" => {
             let Some(path) = artifact_set.pdf_path else {
@@ -2092,7 +2100,7 @@ async fn artifact_handler(
                 return (StatusCode::NOT_FOUND, Html(html)).into_response();
             };
             serve_pdf_artifact(
-                path,
+                &path,
                 &artifact_set.report_title,
                 &run_id,
                 wants_download,
@@ -2114,7 +2122,7 @@ async fn artifact_handler(
                 .unwrap_or_else(|_| "<pre>JSON not available.</pre>".to_string());
                 return (StatusCode::NOT_FOUND, Html(html)).into_response();
             };
-            serve_json_artifact(path, wants_download, &csp_nonce)
+            serve_json_artifact(&path, wants_download, &csp_nonce)
         }
         "scan-config" => {
             let path = artifact_set.output_dir.join("scan-config.json");


### PR DESCRIPTION
## Summary

- Introduce `MetadataPolicyOutcome` enum in `sloc-core` to replace `Option<Option<FileRecord>>` (eliminates `option_option` + `unnecessary_wraps`)
- Simplify `check_content_policy` return type from `Result<tuple>` to bare tuple
- Bundle 4 bool params of `classify_ts_line` into `TsLineFlags` struct; mark `const fn`
- Fix `ref_option`, `needless_pass_by_value` (×5), `map_unwrap_or`, `manual_let_else` (×2), `doc_markdown`, `must_use_candidate` (×2), `or_fun_call`, `duration_suboptimal_units`, `significant_drop_tightening` (×2), `missing_const_for_fn` (×2), `too_long_first_doc_paragraph`
- `#[allow(clippy::too_many_lines)]` with rationale on `serve` and `analyze_handler` (async/Send complexity makes extraction risky)

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features --offline -- -W clippy::pedantic -W clippy::nursery -A clippy::multiple_crate_versions` — zero warnings
- [x] `cargo test --workspace --offline` — all 12 suites pass
- [x] `cargo fmt --all --offline -- --check` — clean

Closes SonarQube findings A2, A3, A4 (19 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)