### PR TITLE
fix(docker): resolve 4 SonarQube Dockerfile findings (A1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Stage 1: build the release binary
 # Pin builder to digest so the toolchain cannot change silently under CI.
 # To refresh: docker pull rust:slim && docker inspect --format '{{index .RepoDigests 0}}' rust:slim
-FROM rust:slim@sha256:715efd1ccdc4a63bd6a6e2f54387fff73f904b70e610d41b4d9d74ff38e13ad3 AS builder
+FROM rust@sha256:715efd1ccdc4a63bd6a6e2f54387fff73f904b70e610d41b4d9d74ff38e13ad3 AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
@@ -25,14 +25,18 @@ RUN sha256sum -c vendor.tar.xz.sha256 \
 # context. If crates/ is accidentally re-added to .dockerignore this produces a
 # clear, actionable error instead of a cryptic Cargo manifest failure.
 RUN test -d crates/sloc-config \
-    || { echo "ERROR: crates/sloc-config is missing from the Docker build context. Check .dockerignore — crates/ must not be excluded."; exit 1; }
+    || { \
+         echo "ERROR: crates/sloc-config is missing from the Docker build context." >&2; \
+         echo "Check .dockerignore — crates/ must not be excluded." >&2; \
+         exit 1; \
+       }
 
 RUN cargo build --release -p oxide-sloc
 
 # Stage 2: minimal runtime image
 # Pin to a specific digest to prevent silent base-image substitution (FIND-006).
 # To update: docker pull debian:bookworm-slim && docker inspect --format '{{index .RepoDigests 0}}' debian:bookworm-slim
-FROM debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
+FROM debian@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
 
 # Install Chromium for PDF export (headless).
 # For a fully air-gapped Docker host, build this layer from a pre-populated

--- a/ci/jenkins/Dockerfile.agent
+++ b/ci/jenkins/Dockerfile.agent
@@ -70,11 +70,8 @@ RUN set -eux; \
               --component rustfmt clippy \
               --no-modify-path; \
     rm /tmp/rust-toolchain.toml; \
-    chmod -R a+rX /opt/rust-toolchain
-
-# Pre-create the persistent Rust+vendor cache directory so the Jenkins user can
-# write to it without requiring root on first use.
-RUN mkdir -p /var/jenkins_home/.rust-cache && \
+    chmod -R a+rX /opt/rust-toolchain; \
+    mkdir -p /var/jenkins_home/.rust-cache; \
     chown -R jenkins:jenkins /var/jenkins_home/.rust-cache
 
 USER jenkins


### PR DESCRIPTION
## Summary

- `Dockerfile:4` — drop `:slim` tag, keep digest only (docker:S8431 — tag+digest conflict)
- `Dockerfile:28` — break overlong pre-flight `RUN` line across multiple lines with `\` continuations (docker:S7020)
- `Dockerfile:35` — drop `:bookworm-slim` tag, keep digest only (docker:S8431)
- `ci/jenkins/Dockerfile.agent:62` — merge two consecutive `RUN` instructions (rustup install + rust-cache dir setup) into a single layer (docker:S7031)

## Test plan

- [x] Dockerfile syntax verified (no build context change — logic is identical)
- [x] Dockerfile.agent layer count reduced by 1 (net effect: smaller image layer graph)

Closes SonarQube findings A1 (4 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)