### PR TITLE
ci(jenkins): SonarQube scan stage, clippy_to_sonar.py, lint-flag upgrade (B1/B3)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,6 +156,12 @@ pipeline {
                           'Use on agents without loopback access or where port 4317 is unavailable.'
         )
 
+        booleanParam(
+            name:         'SKIP_SONAR',
+            defaultValue: false,
+            description:  'Skip the SonarQube scan stage. Use on agents without Docker access or when the SonarQube server is unavailable.'
+        )
+
         // ── Delivery / notifications ───────────────────────────────────────────
         string(
             name:         'WEBHOOK_URL',
@@ -316,7 +322,15 @@ CARGOEOF
                             steps { sh 'cargo fmt --all -- --check' }
                         }
                         stage('Lint') {
-                            steps { sh 'cargo clippy --workspace --all-targets --all-features -- -D warnings' }
+                            steps {
+                                sh '''
+                                    cargo clippy --workspace --all-targets --all-features \
+                                        -- -D warnings \
+                                           -W clippy::pedantic \
+                                           -W clippy::nursery \
+                                           -A clippy::multiple_crate_versions
+                                '''
+                            }
                         }
                     }
                 }
@@ -469,7 +483,40 @@ CARGOEOF
             }
         }
 
-        // ── 5. Web UI health check ─────────────────────────────────────────────
+        // ── 5. SonarQube scan ──────────────────────────────────────────────────
+        // Runs cargo clippy in JSON mode, converts to SonarQube generic-issue
+        // format via scripts/clippy_to_sonar.py, then launches the scanner
+        // container. Results appear in the SonarQube dashboard at http://10.0.0.8:9000
+        //
+        // Prerequisite: add a Jenkins credential named 'sonarqube-oxide-sloc-token'
+        // (Kind: Secret text) containing the SonarQube analysis token.
+        stage('SonarQube scan') {
+            when { expression { !params.SKIP_SONAR } }
+            environment {
+                SONAR_TOKEN = credentials('sonarqube-oxide-sloc-token')
+            }
+            steps {
+                sh '''
+                    # Produce clippy JSON for SonarQube external-issue import.
+                    cargo clippy --workspace --all-targets --all-features \
+                        --message-format=json --offline \
+                        -- -W clippy::pedantic -W clippy::nursery \
+                           -A clippy::multiple_crate_versions \
+                        > clippy.json 2> clippy.stderr || true
+
+                    python3 scripts/clippy_to_sonar.py \
+                        clippy.json clippy-sonar.json "$WORKSPACE"
+
+                    docker run --rm --network host \
+                        -e SONAR_TOKEN \
+                        -v "$WORKSPACE":/usr/src -w /usr/src \
+                        sonarsource/sonar-scanner-cli:latest \
+                        sonar-scanner -Dsonar.host.url=http://10.0.0.8:9000
+                '''
+            }
+        }
+
+        // ── 6. Web UI health check ─────────────────────────────────────────────
         stage('Web UI health check') {
             when { expression { !params.SKIP_WEB_CHECK } }
             steps {

--- a/scripts/clippy_to_sonar.py
+++ b/scripts/clippy_to_sonar.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Convert `cargo clippy --message-format=json` output to SonarQube generic external-issues JSON."""
+import json, os, sys
+
+LEVEL_TO_IMPACT = {
+    "error":   ("RELIABILITY",    "HIGH"),
+    "warning": ("MAINTAINABILITY","MEDIUM"),
+    "note":    ("MAINTAINABILITY","LOW"),
+    "help":    ("MAINTAINABILITY","INFO"),
+}
+
+def normalize_path(p, root):
+    if os.path.isabs(p):
+        try:    return os.path.relpath(p, root)
+        except ValueError: return p
+    return p
+
+def main():
+    src, out = sys.argv[1], sys.argv[2]
+    project_root = sys.argv[3] if len(sys.argv) > 3 else os.getcwd()
+    rules, issues, seen = {}, [], set()
+    for line in open(src):
+        line=line.strip()
+        if not line: continue
+        try: d = json.loads(line)
+        except json.JSONDecodeError: continue
+        if d.get("reason") != "compiler-message": continue
+        msg  = d.get("message") or {}
+        code = (msg.get("code") or {}).get("code")
+        if not code or not code.startswith("clippy::"): continue
+        primary = next((s for s in (msg.get("spans") or []) if s.get("is_primary")), None)
+        if not primary: continue
+        path = normalize_path(primary["file_name"], project_root)
+        key  = (code, path, primary["line_start"], primary["column_start"], msg.get("message",""))
+        if key in seen: continue
+        seen.add(key)
+        sq, sev = LEVEL_TO_IMPACT.get(msg.get("level","warning"), ("MAINTAINABILITY","MEDIUM"))
+        rules.setdefault(code, {
+            "id": code,
+            "name": code,
+            "description": code,
+            "engineId": "clippy",
+            "cleanCodeAttribute": "CONVENTIONAL",
+            "impacts": [{"softwareQuality": sq, "severity": sev}],
+        })
+        issues.append({
+            "ruleId": code,
+            "engineId": "clippy",
+            "type": "CODE_SMELL",
+            "primaryLocation": {
+                "message": msg.get("message",""),
+                "filePath": path,
+                "textRange": {
+                    "startLine": primary["line_start"],
+                    "endLine":   primary["line_end"],
+                    "startColumn": max(0, primary["column_start"]-1),
+                    "endColumn":   max(1, primary["column_end"]-1),
+                },
+            },
+        })
+    json.dump({"rules": list(rules.values()), "issues": issues}, open(out,"w"), indent=2)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **`scripts/clippy_to_sonar.py`** (new) — converts `cargo clippy --message-format=json` to SonarQube generic external-issues format; deduplicates findings; maps clippy severity to SonarQube quality/impact levels
- **Lint stage** — adds `-W clippy::pedantic -W clippy::nursery -A clippy::multiple_crate_versions` so local Jenkins CI surfaces the same lint set that SonarQube measures (using `-W` not `-D` until issue count reaches zero)
- **`SKIP_SONAR` param** — boolean (default `false`); lets operators skip the scan on agents without Docker or when the SonarQube server is unavailable
- **Stage 5 "SonarQube scan"** — inserted between _Analyze_ and _Web UI Check_; binds `SONAR_TOKEN` from Jenkins credential `sonarqube-oxide-sloc-token`; runs clippy JSON → `clippy_to_sonar.py` → `sonar-scanner` container at `http://10.0.0.8:9000`

## Test plan

- [x] Jenkinsfile syntax valid (declarative pipeline linter passes)
- [x] `scripts/clippy_to_sonar.py` produces valid JSON on sample clippy output
- [ ] First live build with `SKIP_SONAR=false` will publish scan results to SonarQube dashboard (requires `sonarqube-oxide-sloc-token` credential to be added in Jenkins)

## Required Jenkins setup

Add credential **`sonarqube-oxide-sloc-token`** (Kind: Secret text) containing the SonarQube analysis token (`sqa_…`) before enabling this stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)