### PR TITLE
fix(jenkins): sandbox off in job-config, CSP docs clarified, preflight host-check improved

### DIFF
--- a/ci/jenkins/job-config.xml
+++ b/ci/jenkins/job-config.xml
@@ -32,6 +32,7 @@
     </scm>
     <scriptPath>Jenkinsfile</scriptPath>
     <lightweight>true</lightweight>
+    <sandbox>false</sandbox>
   </definition>
   <disabled>false</disabled>
 </flow-definition>

--- a/ci/jenkins/job-config.xml.tmpl
+++ b/ci/jenkins/job-config.xml.tmpl
@@ -33,6 +33,7 @@
     </scm>
     <scriptPath>Jenkinsfile</scriptPath>
     <lightweight>true</lightweight>
+    <sandbox>false</sandbox>
   </definition>
   <disabled>false</disabled>
 </flow-definition>

--- a/ci/jenkins/preflight.sh
+++ b/ci/jenkins/preflight.sh
@@ -193,8 +193,13 @@ if [ -z "$CSP" ] || [ "$CSP" = "null" ]; then
                 fi
             else
                 JENKINS_CONTAINER=$(echo "$DOCKER_PS_OUT" | grep -i jenkins | head -1 || true)
+                # If name-grep finds nothing, try by ancestor image as a fallback.
                 if [ -z "$JENKINS_CONTAINER" ]; then
-                    fail "--install-csp: no Jenkins container found in 'docker ps' output. Start your Jenkins container first."
+                    JENKINS_CONTAINER=$($DOCKER_CMD ps --filter ancestor=jenkins/jenkins \
+                        --format '{{.Names}}' 2>/dev/null | head -1 || true)
+                fi
+                if [ -z "$JENKINS_CONTAINER" ]; then
+                    fail "--install-csp can only run on the Jenkins host — no Jenkins container was found in 'docker ps'. Run this script on the machine where the Jenkins container is running, or deploy relax-csp.groovy manually (see docs/jenkins-manual-setup.md Step 6)."
                 else
                     $DOCKER_CMD exec "$JENKINS_CONTAINER" mkdir -p /var/jenkins_home/init.groovy.d
                     $DOCKER_CMD cp "$CSP_GROOVY" "${JENKINS_CONTAINER}:/var/jenkins_home/init.groovy.d/relax-csp.groovy"

--- a/docs/jenkins-manual-setup.md
+++ b/docs/jenkins-manual-setup.md
@@ -312,22 +312,46 @@ The Setup stage attempts to relax the artifact-viewer Content Security Policy vi
 config) and, as a fallback, via the Jenkins Script Console REST API.  The REST API
 path requires an admin API token bound as a Jenkins credential:
 
+**Important — sandbox is ON by default for SCM-defined pipelines.** When a Pipeline
+job pulls its `Jenkinsfile` from SCM, Jenkins enforces the Groovy sandbox by default.
+With the sandbox active, the in-pipeline `System.setProperty` call is always blocked
+("Direct CSP set blocked (sandbox active)"), so the REST API fallback becomes the only
+in-pipeline path available.  This makes the `jenkins-api-token` credential **effectively
+required** on a fresh install — unless you also disable the sandbox.
+
+Disabling the sandbox is exactly what `<sandbox>false</sandbox>` in
+`ci/jenkins/job-config.xml` and `ci/jenkins/job-config.xml.tmpl` does.  If you
+imported the job using `job-config.xml` the sandbox is already off.  If you created
+the job through the web UI, go to **Configure → Pipeline → Advanced** and uncheck
+**"Use Groovy Sandbox"** — or simply add this credential and leave the sandbox on.
+
 | Field | Value |
 |-------|-------|
 | Kind | **Secret text** |
 | Secret | Your Jenkins admin API token — see `ci/jenkins/README.md § Minting a long-lived API token` |
 | ID | `jenkins-api-token` |
 
-Without this credential and with the Groovy sandbox enabled, the pipeline still works
-but the HTML report may render with broken interactive features.  The permanent fix is
-[Step 6](#6-configure-the-csp-header-html-report-viewer) (recommended).
+Without this credential **and** with the Groovy sandbox enabled, the pipeline still
+works but the HTML report may render with broken interactive features.  The permanent
+fix is [Step 6](#6-configure-the-csp-header-html-report-viewer) — the only approach
+that is guaranteed to work regardless of sandbox state.
 
 ---
 
 ## 6. Configure the CSP header (HTML report viewer)
 
 By default, Jenkins's Content Security Policy blocks the inline styles and scripts
-in the oxide-sloc HTML report.  Fix this with an init script:
+in the oxide-sloc HTML report.  **The only reliable fix is deploying a Groovy init
+script** — do this before running any real build.
+
+> **Why not the in-pipeline `System.setProperty` approach?** The Jenkinsfile Setup
+> stage contains a `System.setProperty` call as a convenience, but it is blocked by
+> the Groovy sandbox on fresh installs (see Step 5g), and even when the sandbox is
+> off it only takes effect for the duration of that build's JVM session.  Treat the
+> in-pipeline path as a **diagnostic fallback only**.  Use the init script below for
+> all production setups — it survives restarts and requires no credentials.
+
+### Step-by-step: deploy relax-csp.groovy (init.groovy.d approach)
 
 1. Find your `$JENKINS_HOME`:
    - Docker: `/var/jenkins_home`
@@ -335,30 +359,46 @@ in the oxide-sloc HTML report.  Fix this with an init script:
 
 2. Create the `init.groovy.d` directory if it doesn't exist:
    ```bash
-   sudo mkdir -p $JENKINS_HOME/init.groovy.d
+   # Docker:
+   docker exec -u root <container-name> mkdir -p /var/jenkins_home/init.groovy.d
+   # Native:
+   sudo mkdir -p /var/lib/jenkins/init.groovy.d
    ```
 
-3. Copy the provided Groovy script:
+3. Copy the provided Groovy script into Jenkins:
    ```bash
-   sudo cp ci/jenkins/init.groovy.d/relax-csp.groovy $JENKINS_HOME/init.groovy.d/
+   # Docker (discover container name first: docker ps --format '{{.Names}}' | grep -i jenkins):
+   docker cp ci/jenkins/init.groovy.d/relax-csp.groovy <container-name>:/var/jenkins_home/init.groovy.d/
+   # Native:
+   sudo cp ci/jenkins/init.groovy.d/relax-csp.groovy /var/lib/jenkins/init.groovy.d/
    ```
-   Or paste this content into a new file at that path:
+   Or paste this content manually into a new file at that path:
    ```groovy
    // $JENKINS_HOME/init.groovy.d/relax-csp.groovy
-   import hudson.model.Hudson
    System.setProperty(
-     "hudson.model.DirectoryBrowserSupport.CSP",
-     "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; img-src 'self' data:;"
+     'hudson.model.DirectoryBrowserSupport.CSP',
+     "default-src 'self'; style-src 'self' 'unsafe-inline'; " +
+     "img-src 'self' data: blob:; script-src 'self' 'unsafe-inline'; " +
+     "font-src 'self' data:;"
    )
    ```
 
 4. **Restart Jenkins** for the init script to take effect:
-   - Docker: `docker restart jenkins`
-   - Native: `sudo systemctl restart jenkins`
+   ```bash
+   # Docker:
+   docker restart <container-name>
+   # Native:
+   sudo systemctl restart jenkins
+   ```
+
+5. Verify the CSP is set by running `bash ci/jenkins/preflight.sh` — the `[warn] CSP at default`
+   message should be gone.
 
 > **Without this step**, the "OxideSLOC — Jenkins CI Report" and "OxideSLOC — Jenkins HTML Report"
 > pages will render with broken interactive features (CSS still loads, but JS is blocked — see
-> Step 11 for full symptoms).
+> Step 11 for full symptoms).  The `preflight.sh` script also supports
+> `bash ci/jenkins/preflight.sh --install-csp` (requires Docker on the Jenkins host) to deploy
+> and restart automatically.
 
 ---
 


### PR DESCRIPTION
## Summary

- **`ci/jenkins/job-config.xml` + `.tmpl`** — Add `<sandbox>false</sandbox>` inside `<definition class="…CpsScmFlowDefinition">`. Without this, the Setup-stage `System.setProperty` CSP call is always blocked on fresh installs where the Groovy sandbox is ON by default for SCM-defined pipelines.
- **`docs/jenkins-manual-setup.md` Step 5g** — Explain that the Groovy sandbox is ON by default for SCM-defined pipeline jobs, making `jenkins-api-token` effectively required unless the sandbox is disabled (which `job-config.xml` now does). Documents the web-UI path for users who created the job manually.
- **`docs/jenkins-manual-setup.md` Step 6** — Lead with `init.groovy.d` as the only reliable CSP fix (survives restarts, needs no credentials). Demote the in-pipeline `System.setProperty` approach to a clearly-labelled **diagnostic fallback only**. Expand Step 6 with concrete Docker and native commands for both setup paths, and a verification step.
- **`ci/jenkins/preflight.sh` `--install-csp`** — When no Jenkins container is found via name-grep, also try `docker ps --filter ancestor=jenkins/jenkins` before giving up. If still nothing found, emit `"--install-csp can only run on the Jenkins host"` instead of the generic "Start your Jenkins container first" message, which confused operators running from a remote workstation.

## Test plan

- [ ] Import `job-config.xml` into a fresh Jenkins instance and confirm the Groovy Sandbox checkbox is unchecked in **Configure → Pipeline → Advanced**.
- [ ] Run `bash ci/jenkins/preflight.sh` from a machine without the Jenkins container and confirm the new `"can only run on the Jenkins host"` message appears.
- [ ] Run Step 6 instructions on a Docker-based Jenkins install and confirm `[warn] CSP at default` is gone after `preflight.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)